### PR TITLE
api: refactor url creation

### DIFF
--- a/api.go
+++ b/api.go
@@ -1,24 +1,32 @@
 package main
 
-import(
-	"time" // used to get current date for API call
+import (
+	"net/url"
 	"strings"
+	"time" // used to get current date for API call
 )
 
-const ApiKey string = "B63dwvvoZp5Kh47nTVcvRg3Mf1SbkBvCkrAkFbSA" // eventually will be gotten by
+const baseUrl string = "https://www.rescuetime.com/anapi/data"
 
-func GenerateRequest(ApiKey string)(string){
+func GenerateRequest(apiKey string) (string, error) {
 	date := time.Now()
 	today := strings.Fields(date.String())[0]
-	var apiCall string
-	apiCall += "https://www.rescuetime.com/anapi/data?key="
-	apiCall += ApiKey
-	apiCall += "&perspective=interval&restrict_kind=productivity&interval=hour&restrict_begin="
-	apiCall += today
-	apiCall += "&restrict_end="
-	apiCall += today
-	apiCall += "&format=csv"
-	return apiCall
+
+	u, err := url.Parse(baseUrl)
+	if err != nil {
+		return "", err
+	}
+
+	q := u.Query()
+	q.Set("key", apiKey)
+	q.Set("perspective", "interval")
+	q.Set("restrict_kind", "productivity")
+	q.Set("interval", "hour")
+	q.Set("restrict_begin", today)
+	q.Set("restrict_end", today)
+	q.Set("format", "csv")
+
+	u.RawQuery = q.Encode()
+
+	return u.String(), nil
 }
-
-

--- a/rtc.go
+++ b/rtc.go
@@ -1,97 +1,103 @@
 package main
 
-import(
-	"github.com/spf13/cobra"
-	"github.com/boltdb/bolt"
-	"net/http"
+import (
 	"encoding/csv"
-	"strconv"
-	"log"
 	"errors"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/boltdb/bolt"
+	"github.com/spf13/cobra"
 )
 
-type RTDay struct{
-	Date string
-	TimeSpent int
+type RTDay struct {
+	Date           string
+	TimeSpent      int
 	NumberofPeople int // normally should return one since this is a personal tool! :)
-	Productivity int
+	Productivity   int
 }
 
-type results struct{
-	TotalTimeSpent uint
-	VeryProductive uint
-	Productive uint
-	Nuetral uint
-	Unproductive uint
-	VeryUnproductive uint
-	NuetralThreshold uint
-	NuetralThresholdReached bool
-	UnproductiveThreshold uint
+type results struct {
+	TotalTimeSpent               uint
+	VeryProductive               uint
+	Productive                   uint
+	Nuetral                      uint
+	Unproductive                 uint
+	VeryUnproductive             uint
+	NuetralThreshold             uint
+	NuetralThresholdReached      bool
+	UnproductiveThreshold        uint
 	UnproductiveThresholdReached bool
 }
 
-// enums used to tell which mode to be in 
+// enums used to tell which mode to be in
 type mode int
-const(
-	Day    mode = 0
-	Week   mode = 1
-	Month  mode = 2
+
+const (
+	Day   mode = 0
+	Week  mode = 1
+	Month mode = 2
 )
 
 var rootCmd = &cobra.Command{
-	Use: "",
+	Use:                "",
 	DisableFlagParsing: true, // all flags passed as arguments
-	Short: "Display rescuetime data",
-	Run: func(cmd *cobra.Command, args []string){ // args is gonna be what we pass through 
-		if len(args) == 0 || args[0] == "d"{ // default is to just do the day
+	Short:              "Display rescuetime data",
+	Run: func(cmd *cobra.Command, args []string) { // args is gonna be what we pass through
+		if len(args) == 0 || args[0] == "d" { // default is to just do the day
 			db, err := bolt.Open("RescueTimeDatabase.db", 0600, nil)
-			if err != nil{
+			if err != nil {
 				log.Fatal("Database not found: run ./rtc init")
 			}
 			defer db.Close()
 
 			if err := db.View(func(tx *bolt.Tx) error {
 				bucket := tx.Bucket([]byte("apiAuth"))
-				if bucket == nil{
+				if bucket == nil {
 					return errors.New("Database err: Bucket not found ---> suggestion: run ./rtc init")
 				}
 				c := bucket.Cursor() // breaks because we are not in a transaction
 				_, apiKey := c.Seek([]byte("apiAuth"))
-				if apiKey == nil{
+				if apiKey == nil {
 					return errors.New("Database err: APIKey not found ---> suggestion: run ./rtc init")
 				}
-				request := GenerateRequest(string(apiKey)) // generates our request for us
+				request, err := GenerateRequest(string(apiKey)) // generates our request for us
+				if err != nil {
+					return errors.New("Api err: unable to create proper api url ---> suggestion: file a github issue")
+				}
+
 				resp, err := http.Get(request)
-				if err != nil{
+				if err != nil {
 					return errors.New("Database error ---> suggestion: run ./rtc init")
 				}
 
-				data , err := csv.NewReader(resp.Body).ReadAll()
-				if err != nil{
+				data, err := csv.NewReader(resp.Body).ReadAll()
+				if err != nil {
 					return err
 				}
 
 				bufferResults := results{
-					TotalTimeSpent: 0,
-					VeryUnproductive: 0,
-					Unproductive: 0,
-					Nuetral: 0,
-					Productive: 0,
-					VeryProductive: 0,
-					NuetralThreshold:10,
-					NuetralThresholdReached: false,
-					UnproductiveThreshold:10,
+					TotalTimeSpent:               0,
+					VeryUnproductive:             0,
+					Unproductive:                 0,
+					Nuetral:                      0,
+					Productive:                   0,
+					VeryProductive:               0,
+					NuetralThreshold:             10,
+					NuetralThresholdReached:      false,
+					UnproductiveThreshold:        10,
 					UnproductiveThresholdReached: false,
 				}
 
-				for _, day := range data[1:]{
+				for _, day := range data[1:] {
 					timeSpentBuffer, _ := strconv.Atoi(day[1])
 					timeSpent := uint(timeSpentBuffer)
 					productivity, _ := strconv.Atoi(day[3])
 
 					bufferResults.TotalTimeSpent += uint(timeSpent)
 
-					switch productivity{
+					switch productivity {
 					case -2:
 						bufferResults.VeryUnproductive += timeSpent
 					case -1:
@@ -105,25 +111,24 @@ var rootCmd = &cobra.Command{
 					}
 				}
 
-				if float64(bufferResults.Nuetral) / float64(bufferResults.TotalTimeSpent) > float64(bufferResults.NuetralThreshold){
+				if float64(bufferResults.Nuetral)/float64(bufferResults.TotalTimeSpent) > float64(bufferResults.NuetralThreshold) {
 					bufferResults.NuetralThresholdReached = true
 				}
 
-				if float64(bufferResults.Unproductive + bufferResults.VeryUnproductive) / float64(bufferResults.TotalTimeSpent) > float64(bufferResults.UnproductiveThreshold){
+				if float64(bufferResults.Unproductive+bufferResults.VeryUnproductive)/float64(bufferResults.TotalTimeSpent) > float64(bufferResults.UnproductiveThreshold) {
 					bufferResults.NuetralThresholdReached = true
 				}
 				bufferResults.Output(Day)
 				return nil
-			}); err != nil{
+			}); err != nil {
 				log.Fatal(err)
 			}
-		}else if args[0] == "w" {
+		} else if args[0] == "w" {
 			return
 			//bufferResults.Ouput(Week)
-		}else{
+		} else {
 			return
 			//bufferResults.Ouput(Week)
 		}
 	},
 }
-


### PR DESCRIPTION
Making a small refactoring in the `GenerateRequest` method, to generate the
urls using a query builder. To read more on this particular method, please
reference [url.Query()](https://golang.org/pkg/net/url/#URL.Query)

Also, as a suggestion my recommendation would be to avoid calling the method
`GenerateRequest`. It's actually not generating a request, it's creating a url.
A humble suggestion might be to name it `generateRequest`.

Another suggestion could be to encapsulate all of the rescuetime api request
logic into a single `doRescueTime` method - it could do the request, handle
adding times and errors etc for you.